### PR TITLE
Fix issue #4

### DIFF
--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -20,6 +20,8 @@ for V ∈ (:Vec, :Normal)
             z::T
         end
 
+        $V(x, y, z) = $V(promote(x, y, z)...)
+
         # Show in compact mode (i.e. inside a container)
         function show(io::IO, a::$V)
             print(io, typeof(a), "(", join((string(el) for el ∈ a), ", "), ")")


### PR DESCRIPTION
Proposed fix to issue #4 regarding the default constructors given by the `StaticArrays` libraries and already reported [here](https://github.com/JuliaArrays/StaticArrays.jl/issues/869). We implement the solution proposed [here](https://github.com/JuliaArrays/StaticArrays.jl/issues/869#issuecomment-761809419) into `geometry.jl`. This seems to fix the bug.